### PR TITLE
Add AWS Signature v4 Signing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe("dynamo", function() {
     })
   })
   describe("'PutItem' x 50 using Session", function() {
-    var sessionDb = dynamo.createClient(host, true)
+    var sessionDb = dynamo.createClient(host, new dynamo.Session())
     it("should not throw ProvisionedThroughputExceededException", function(done) {
       for (var i = 0, n = 50, e = null; i < n; i++) {
         sessionDb.request("PutItem", {


### PR DESCRIPTION
This pull request adds Signature v4 signing and turns it on by default (as does the official AWS lib)

There are no breaking changes, but the is an extra parameter, `useSession`, to allow for session signing:

``` javascript
var sigV4Db = dynamo.createClient(host)
var sigV4Db2 = dynamo.createClient(host, credentials)
var sessionDb = dynamo.createClient(host, true)
var sessionDb2 = dynamo.createClient(host, credentials, true)
```

(another option would be to add `useSession` to `credentials`)

It's not quite as clean as I'd like - but I didn't want to change the existing structure of things too much. Feel free to chop and change of course!
